### PR TITLE
fix: correct typos 'Ubutuntu' → 'Ubuntu' and 'settup' → 'setup' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The first open source all-screen keyboard. This repository contains all the digi
 * Various wires and cables to put everything together
 
 ### To enable SPI on Raspberry Pi running Ubuntu
-Due to the 3840x1100 wide display resolution, Raspbian cannot be used. Ubutuntu then requires a little more settup to access all the Pi's features. 
+Due to the 3840x1100 wide display resolution, Raspbian cannot be used. Ubuntu then requires a little more setup to access all the Pi's features. 
 In /boot/firmware/config.txt place the following text
 ```
 enable_uart=1


### PR DESCRIPTION
## Summary

Fixes #14

Two typos in the Ubuntu SPI setup section of README.md (line 15):

- `Ubutuntu` → `Ubuntu` (transposed letters)
- `settup` → `setup` (doubled t)